### PR TITLE
feat: exchange Metal API keys for LB API OAuth2 tokens

### DIFF
--- a/internal/lbaas/v1/configuration.go
+++ b/internal/lbaas/v1/configuration.go
@@ -93,7 +93,7 @@ func NewConfiguration() *Configuration {
 		Debug:         false,
 		Servers: ServerConfigurations{
 			{
-				URL:         "https://lb.metalctrl.io/v1",
+				URL:         "https://lb.metalctrl.io",
 				Description: "Production Server",
 			},
 		},

--- a/metal/loadbalancers.go
+++ b/metal/loadbalancers.go
@@ -93,7 +93,7 @@ func newLoadBalancers(client *packngo.Client, k8sclient kubernetes.Interface, pr
 		impl = empty.NewLB(k8sclient, lbconfig)
 	case "emlb":
 		klog.Info("loadbalancer implementation enabled: emlb")
-		impl = emlb.NewLB(k8sclient, lbconfig)
+		impl = emlb.NewLB(k8sclient, lbconfig, client.APIKey, projectID)
 	default:
 		klog.Info("loadbalancer implementation disabled")
 		impl = nil

--- a/metal/loadbalancers/emlb/controller.go
+++ b/metal/loadbalancers/emlb/controller.go
@@ -1,0 +1,98 @@
+package emlb
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	lbaas "github.com/equinix/cloud-provider-equinix-metal/internal/lbaas/v1"
+)
+
+const ProviderID = "loadpvd-gOB_-byp5ebFo7A3LHv2B"
+
+var LBMetros = map[string]string{
+	"da": "lctnloc--uxs0GLeAELHKV8GxO_AI",
+	"ny": "lctnloc-Vy-1Qpw31mPi6RJQwVf9A",
+	"sv": "lctnloc-H5rl2M2VL5dcFmdxhbEKx",
+}
+
+type controller struct {
+	client         *lbaas.APIClient
+	tokenExchanger *MetalTokenExchanger
+}
+
+func NewController(metalAPIKey string) *controller {
+	controller := &controller{}
+	emlbConfig := lbaas.NewConfiguration()
+
+	controller.client = lbaas.NewAPIClient(emlbConfig)
+	controller.tokenExchanger = &MetalTokenExchanger{
+		metalAPIKey: metalAPIKey,
+		client:      controller.client.GetConfig().HTTPClient,
+	}
+
+	return controller
+}
+
+func (c *controller) createLoadBalancer(ctx context.Context, config map[string]string) (map[string]string, error) {
+	outputProperties := map[string]string{}
+
+	ctx = context.WithValue(ctx, lbaas.ContextOAuth2, c.tokenExchanger)
+
+	metro := config["metro"]
+
+	locationId, ok := LBMetros[metro]
+	if !ok {
+		return nil, fmt.Errorf("could not determine load balancer location for metro %v; valid values are %v", metro, reflect.ValueOf(LBMetros).Keys())
+	}
+	lbCreateRequest := lbaas.LoadBalancerCreate{
+		Name:       "", // TODO generate from service definition.  Maybe "svcNamespace:svcName"?  Do we need to know the cluster name here?
+		LocationId: locationId,
+		ProviderId: ProviderID,
+	}
+
+	// TODO lb, resp, err :=
+	_, _, err := c.client.ProjectsApi.CreateLoadBalancer(ctx, "TODO: project ID").LoadBalancerCreate(lbCreateRequest).Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO create other resources
+	return outputProperties, nil
+}
+
+func (c *controller) updateLoadBalancer(ctx context.Context, id string, config map[string]string) (map[string]string, error) {
+	outputProperties := map[string]string{}
+
+	ctx = context.WithValue(ctx, lbaas.ContextOAuth2, c.tokenExchanger)
+
+	// TODO delete other resources
+
+	// TODO lb, resp, err :=
+	_, err := c.client.LoadBalancersApi.DeleteLoadBalancer(ctx, id).Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	return outputProperties, nil
+}
+
+func (c *controller) deleteLoadBalancer(ctx context.Context, id string, config map[string]string) (map[string]string, error) {
+	outputProperties := map[string]string{}
+
+	tokenExchanger := &MetalTokenExchanger{
+		metalAPIKey: "TODO",
+		client:      c.client.GetConfig().HTTPClient,
+	}
+	ctx = context.WithValue(ctx, lbaas.ContextOAuth2, tokenExchanger)
+
+	// TODO delete other resources
+
+	// TODO lb, resp, err :=
+	_, err := c.client.LoadBalancersApi.DeleteLoadBalancer(ctx, id).Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	return outputProperties, nil
+}

--- a/metal/loadbalancers/emlb/controller.go
+++ b/metal/loadbalancers/emlb/controller.go
@@ -19,9 +19,11 @@ var LBMetros = map[string]string{
 type controller struct {
 	client         *lbaas.APIClient
 	tokenExchanger *MetalTokenExchanger
+	projectID      string
+	metro          string
 }
 
-func NewController(metalAPIKey string) *controller {
+func NewController(metalAPIKey, projectID, metro string) *controller {
 	controller := &controller{}
 	emlbConfig := lbaas.NewConfiguration()
 
@@ -30,6 +32,8 @@ func NewController(metalAPIKey string) *controller {
 		metalAPIKey: metalAPIKey,
 		client:      controller.client.GetConfig().HTTPClient,
 	}
+	controller.projectID = projectID
+	controller.metro = metro
 
 	return controller
 }

--- a/metal/loadbalancers/emlb/emlb.go
+++ b/metal/loadbalancers/emlb/emlb.go
@@ -28,10 +28,46 @@ func NewLB(k8sclient kubernetes.Interface, config string) *LB {
 }
 
 func (l *LB) AddService(ctx context.Context, svcNamespace, svcName, ip string, nodes []loadbalancers.Node) error {
+	tokenExchanger := &MetalTokenExchanger{
+		metalAPIKey: "", // TODO pass this in somehow (maybe add it to the context?)
+		client:      l.client.GetConfig().HTTPClient,
+	}
+	ctx = context.WithValue(ctx, lbaas.ContextOAuth2, tokenExchanger)
+
+	lbCreateRequest := lbaas.LoadBalancerCreate{
+		Name:       "", // TODO generate from service definition.  Maybe "svcNamespace:svcName"?  Do we need to know the cluster name here?
+		LocationId: "", // TODO In the first pass, this comes from the config string?  Or an annotation
+		ProviderId: "", // TODO I have a working value for this (same as what the portal uses) but waiting on feedback from LBaaS team
+	}
+
+	// TODO lb, resp, err :=
+	_, _, err := l.client.ProjectsApi.CreateLoadBalancer(ctx, "TODO: project ID").LoadBalancerCreate(lbCreateRequest).Execute()
+	if err != nil {
+		return err
+	}
+
+	// TODO create other resources
+
 	return nil
 }
 
 func (l *LB) RemoveService(ctx context.Context, svcNamespace, svcName, ip string) error {
+	tokenExchanger := &MetalTokenExchanger{
+		metalAPIKey: "TODO",
+		client:      l.client.GetConfig().HTTPClient,
+	}
+	ctx = context.WithValue(ctx, lbaas.ContextOAuth2, tokenExchanger)
+
+	loadBalancerId := "TODO"
+
+	// TODO delete other resources
+
+	// TODO lb, resp, err :=
+	_, err := l.client.LoadBalancersApi.DeleteLoadBalancer(ctx, loadBalancerId).Execute()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/metal/loadbalancers/emlb/emlb.go
+++ b/metal/loadbalancers/emlb/emlb.go
@@ -3,11 +3,21 @@ package emlb
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
 	lbaas "github.com/equinix/cloud-provider-equinix-metal/internal/lbaas/v1"
 	"github.com/equinix/cloud-provider-equinix-metal/metal/loadbalancers"
 	"k8s.io/client-go/kubernetes"
 )
+
+const ProviderID = "loadpvd-gOB_-byp5ebFo7A3LHv2B"
+
+var LBMetros = map[string]string{
+	"da": "lctnloc--uxs0GLeAELHKV8GxO_AI",
+	"ny": "lctnloc-Vy-1Qpw31mPi6RJQwVf9A",
+	"sv": "lctnloc-H5rl2M2VL5dcFmdxhbEKx",
+}
 
 type LB struct {
 	client               *lbaas.APIClient
@@ -34,10 +44,16 @@ func (l *LB) AddService(ctx context.Context, svcNamespace, svcName, ip string, n
 	}
 	ctx = context.WithValue(ctx, lbaas.ContextOAuth2, tokenExchanger)
 
+	metro := "da" // TODO get this from somewhere else
+
+	locationId, ok := LBMetros[metro]
+	if !ok {
+		return fmt.Errorf("could not determine load balancer location for metro %v; valid values are %v", metro, reflect.ValueOf(LBMetros).Keys())
+	}
 	lbCreateRequest := lbaas.LoadBalancerCreate{
 		Name:       "", // TODO generate from service definition.  Maybe "svcNamespace:svcName"?  Do we need to know the cluster name here?
-		LocationId: "", // TODO In the first pass, this comes from the config string?  Or an annotation
-		ProviderId: "", // TODO I have a working value for this (same as what the portal uses) but waiting on feedback from LBaaS team
+		LocationId: locationId,
+		ProviderId: ProviderID,
 	}
 
 	// TODO lb, resp, err :=

--- a/metal/loadbalancers/emlb/emlb.go
+++ b/metal/loadbalancers/emlb/emlb.go
@@ -4,28 +4,24 @@ package emlb
 import (
 	"context"
 
-	lbaas "github.com/equinix/cloud-provider-equinix-metal/internal/lbaas/v1"
 	"github.com/equinix/cloud-provider-equinix-metal/metal/loadbalancers"
 	"k8s.io/client-go/kubernetes"
 )
 
 type LB struct {
-	controller           *controller
-	loadBalancerLocation *lbaas.LoadBalancerLocation
+	controller *controller
 }
 
-func NewLB(k8sclient kubernetes.Interface, config string) *LB {
+func NewLB(k8sclient kubernetes.Interface, config, metalAPIKey, projectID string) *LB {
 	// Parse config for Equinix Metal Load Balancer
-	// An example config using Dallas as the location would look like
 	// The format is emlb://<location>
+	// An example config using Dallas as the location would look like emlb://da
 	// it may have an extra slash at the beginning or end, so get rid of it
-
-	metalAPIKey := "TODO"
+	metro := config
 
 	lb := &LB{}
-	lb.loadBalancerLocation.Id = &config
+	lb.controller = NewController(metalAPIKey, projectID, metro)
 
-	lb.controller = NewController(metalAPIKey)
 	return lb
 }
 

--- a/metal/loadbalancers/emlb/emlb.go
+++ b/metal/loadbalancers/emlb/emlb.go
@@ -30,7 +30,12 @@ func NewLB(k8sclient kubernetes.Interface, config string) *LB {
 }
 
 func (l *LB) AddService(ctx context.Context, svcNamespace, svcName, ip string, nodes []loadbalancers.Node) error {
-	// 1. Gather the properties we need: Metal API key, port number(s), cluster name(?), target IP(s?)
+	/*
+		1. Gather the properties we need: Metal API key, port number(s), cluster name(?), target IP(s?)
+		What we need here is:
+			- The NodePort (for first pass we will use the same port on the LB, so if NodePort is 8000 we use 8000 on LB)
+			- The public IPs of the nodes on which the service is running
+	*/
 	additionalProperties := map[string]string{}
 
 	// 2. Create the infrastructure (what do we need to return here?  lb name and/or ID? anything else?)
@@ -40,12 +45,19 @@ func (l *LB) AddService(ctx context.Context, svcNamespace, svcName, ip string, n
 		return err
 	}
 
-	// 3. Add the annotations
+	/*
+		3. Add the annotations
+			- ID of the load balancer
+			- Name of the load balancer
+			- Metro of the load balancer
+			- IP address of the load balancer
+			- Listener port that this service is using
+	*/
 	return nil
 }
 
 func (l *LB) RemoveService(ctx context.Context, svcNamespace, svcName, ip string) error {
-	// 1. Gather the properties we need: Metal API key, port number(s), cluster name(?), target IP(s?)
+	// 1. Gather the properties we need: ID of load balancer
 	loadBalancerId := "TODO"
 	additionalProperties := map[string]string{}
 
@@ -56,13 +68,18 @@ func (l *LB) RemoveService(ctx context.Context, svcNamespace, svcName, ip string
 		return err
 	}
 
-	// 3. Remove the annotations
+	// 3. No need to remove the annotations because the annotated object was deleted
 
 	return nil
 }
 
 func (l *LB) UpdateService(ctx context.Context, svcNamespace, svcName string, nodes []loadbalancers.Node) error {
-	// 1. Gather the properties we need: Metal API key, port number(s), cluster name(?), target IP(s?)
+	/*
+		1. Gather the properties we need:
+			- load balancer ID
+			- NodePort
+			- Public IP addresses of the nodes on which the target pods are running
+	*/
 	loadBalancerId := "TODO"
 	additionalProperties := map[string]string{}
 
@@ -73,7 +90,10 @@ func (l *LB) UpdateService(ctx context.Context, svcNamespace, svcName string, no
 		return err
 	}
 
-	// 3. Update the annotations
+	/*
+		3. Update the annotations
+			- Listener port that this service is using
+	*/
 
 	return nil
 }

--- a/metal/loadbalancers/emlb/metal_token_exchanger.go
+++ b/metal/loadbalancers/emlb/metal_token_exchanger.go
@@ -1,0 +1,57 @@
+package emlb
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+type MetalTokenExchanger struct {
+	metalAPIKey string
+	client      *http.Client
+}
+
+func (m *MetalTokenExchanger) Token() (*oauth2.Token, error) {
+	tokenExchangeURL := "https://iam.metalctrl.io/api-keys/exchange"
+	tokenExchangeRequest, err := http.NewRequest("POST", tokenExchangeURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	tokenExchangeRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %v", m.metalAPIKey))
+
+	resp, err := m.client.Do(tokenExchangeRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token exchange request failed with status %v, body %v", resp.StatusCode, body)
+	}
+
+	token := oauth2.Token{}
+	err = json.Unmarshal(body, &token)
+	if err != nil {
+		fmt.Println(len(body))
+		fmt.Println(token)
+		fmt.Println(err)
+		return nil, err
+	}
+
+	expiresIn := token.Extra("expires_in")
+	if expiresIn != nil {
+		expiresInSeconds := expiresIn.(int)
+		token.Expiry = time.Now().Add(time.Second * time.Duration(expiresInSeconds))
+	}
+
+	return &token, nil
+}


### PR DESCRIPTION
This adds an [`oauth2.TokenSource`](https://pkg.go.dev/golang.org/x/oauth2#TokenSource) that uses the token exchange endpoint to request an OAuth2 JWT for the given API key.

The `TokenSource` is added to the context under the `lbaas.ContextOAuth2` context key.  The load balancer API client automatically looks for a `TokenSource` under that key, uses it to get the OAuth2 token, and adds the token to outgoing requests.